### PR TITLE
Add missing --nice

### DIFF
--- a/slurm-examples/tf.slurm
+++ b/slurm-examples/tf.slurm
@@ -11,6 +11,7 @@
 
 # 使用1个GPU、1个CPU
 #SBATCH --gres=gpu:1
+#SBATCH --nice
 #SBATCH --cpus-per-task=1
 
 # 设置此任务的最长运行时间为7小时56分钟。其他写法参见 https://slurm.schedmd.com/sbatch.html


### PR DESCRIPTION
GPU任务必须加上--nice选项。

![putty_fu7FPttZVD](https://user-images.githubusercontent.com/614159/111990419-37836500-8b4e-11eb-82b3-9fe481417e8a.png)

如图，假设当前集群已经有多个GPU任务在运行了，没有剩余GPU，那么接下来的GPU任务会排队，如job 991, 992, 993。

这时来了一个CPU任务（job 994）。这时，集群虽然GPU全满，但CPU还有空，理应能处理该CPU任务。但是由于排队机制，发现job 994的优先级低于job 991, 992, 993，所以CPU虽空，但不能处理job 994。


基于此发现，我们要求GPU任务必须加上--nice选项。这样的话，排队时GPU任务的优先级默认比CPU任务低。在上述情形，job 994的优先级会高于job 991, 992, 993。并且由于CPU有空，job 994会立即执行。