### PR TITLE
禁止变更nvidia driver

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,3 +18,6 @@ sudo usermod -aG wheel $(whoami)
 sudo systemctl disable motd-news
 sudo chmod -x /etc/update-motd.d/50-motd-news
 
+# 禁止变更nvidia driver
+sudo apt-mark hold 'nvidia*'
+


### PR DESCRIPTION
Fix #30 
```
$ sudo apt-mark hold 'nvidia*'
nvidia-340 set on hold.
nvidia-384 set on hold.
nvidia-settings set on hold.
nvidia-prime set on hold.
nvidia-common set on hold.
nvidia-kernel-common-390 set on hold.
nvidia-dkms-390 set on hold.
nvidia-kernel-common-440 set on hold.
nvidia-dkms-440 set on hold.
nvidia-331 set on hold.
nvidia-331-dev set on hold.
nvidia-340-dev set on hold.
nvidia-331-updates set on hold.
nvidia-331-updates-dev set on hold.
nvidia-331-updates-uvm set on hold.
nvidia-331-uvm set on hold.
nvidia-opencl-icd-340 set on hold.
nvidia-340-updates set on hold.
nvidia-340-updates-dev set on hold.
nvidia-340-uvm set on hold.
nvidia-driver-390 set on hold.
nvidia-384-dev set on hold.
nvidia-compute-utils-390 set on hold.
nvidia-compute-utils-418 set on hold.
nvidia-compute-utils-430 set on hold.
nvidia-compute-utils-440 set on hold.
nvidia-compute-utils-435 set on hold.
nvidia-kernel-source-390 set on hold.
nvidia-dkms-418 set on hold.
nvidia-dkms-430 set on hold.
nvidia-dkms-435 set on hold.
nvidia-kernel-source-435 set on hold.
nvidia-kernel-common-435 set on hold.
nvidia-kernel-source-440 set on hold.
nvidia-utils-390 set on hold.
nvidia-driver-418 set on hold.
nvidia-driver-430 set on hold.
nvidia-driver-440 set on hold.
nvidia-driver-435 set on hold.
nvidia-utils-435 set on hold.
nvidia-utils-440 set on hold.
nvidia-headless-390 set on hold.
nvidia-headless-no-dkms-390 set on hold.
nvidia-headless-418 set on hold.
nvidia-headless-430 set on hold.
nvidia-headless-440 set on hold.
nvidia-headless-435 set on hold.
nvidia-headless-no-dkms-435 set on hold.
nvidia-headless-no-dkms-440 set on hold.
nvidia-headless-no-dkms-418 set on hold.
nvidia-headless-no-dkms-430 set on hold.
nvidia-kernel-common-418 set on hold.
nvidia-kernel-common-430 set on hold.
nvidia-kernel-source-418 set on hold.
nvidia-kernel-source-430 set on hold.
nvidia-libopencl1-340 set on hold.
nvidia-utils-418 set on hold.
nvidia-utils-430 set on hold.
nvidia-cuda-toolkit set on hold.
nvidia-cuda-dev set on hold.
nvidia-cg-toolkit set on hold.
nvidia-opencl-dev set on hold.
nvidia-cg-dev set on hold.
nvidia-cg-doc set on hold.
nvidia-cuda-doc set on hold.
nvidia-cuda-gdb set on hold.
nvidia-profiler set on hold.
nvidia-visual-profiler set on hold.
nvidia-cuda-toolkit-gcc set on hold.
nvidia-libopencl1-331 set on hold.
nvidia-libopencl1-331-updates set on hold.
nvidia-libopencl1-340-updates set on hold.
nvidia-libopencl1-384 set on hold.
nvidia-modprobe set on hold.
nvidia-nsight set on hold.
nvidia-opencl-icd-331 set on hold.
nvidia-opencl-icd-331-updates set on hold.
nvidia-opencl-icd-340-updates set on hold.
nvidia-opencl-icd-384 set on hold.
nvidia-kernel-common-418-server set on hold.
nvidia-dkms-418-server set on hold.
nvidia-kernel-common-450 set on hold.
nvidia-dkms-450 set on hold.
nvidia-kernel-common-450-server set on hold.
nvidia-dkms-450-server set on hold.
nvidia-kernel-common-455 set on hold.
nvidia-kernel-common-460 set on hold.
nvidia-dkms-460 set on hold.
nvidia-kernel-common-460-server set on hold.
nvidia-dkms-460-server set on hold.
nvidia-compute-utils-455 set on hold.
nvidia-compute-utils-450 set on hold.
nvidia-compute-utils-450-server set on hold.
nvidia-compute-utils-460 set on hold.
nvidia-dkms-455 set on hold.
nvidia-kernel-source-450 set on hold.
nvidia-kernel-source-450-server set on hold.
nvidia-kernel-source-460 set on hold.
nvidia-driver-455 set on hold.
nvidia-driver-450 set on hold.
nvidia-utils-450 set on hold.
nvidia-driver-450-server set on hold.
nvidia-utils-450-server set on hold.
nvidia-driver-460 set on hold.
nvidia-utils-460 set on hold.
nvidia-headless-455 set on hold.
nvidia-headless-450 set on hold.
nvidia-headless-no-dkms-450 set on hold.
nvidia-headless-450-server set on hold.
nvidia-headless-no-dkms-450-server set on hold.
nvidia-headless-460 set on hold.
nvidia-headless-no-dkms-460 set on hold.
nvidia-headless-no-dkms-455 set on hold.
nvidia-kernel-source-455 set on hold.
nvidia-utils-455 set on hold.
nvidia-compute-utils-418-server set on hold.
nvidia-compute-utils-440-server set on hold.
nvidia-compute-utils-460-server set on hold.
nvidia-kernel-source-418-server set on hold.
nvidia-dkms-440-server set on hold.
nvidia-kernel-source-460-server set on hold.
nvidia-driver-418-server set on hold.
nvidia-utils-418-server set on hold.
nvidia-driver-440-server set on hold.
nvidia-driver-460-server set on hold.
nvidia-utils-460-server set on hold.
nvidia-headless-418-server set on hold.
nvidia-headless-no-dkms-418-server set on hold.
nvidia-headless-440-server set on hold.
nvidia-headless-460-server set on hold.
nvidia-headless-no-dkms-460-server set on hold.
nvidia-headless-no-dkms-440-server set on hold.
nvidia-kernel-common-440-server set on hold.
nvidia-kernel-source-440-server set on hold.
nvidia-utils-440-server set on hold.
nvidia-container-runtime-hook set on hold.
nvidia-container-runtime set on hold.
nvidia-container-toolkit set on hold.
```

Not sure if the expression for holding is too broad.