### PR TITLE
Randomize the order of GPUs for job allocation

### DIFF
--- a/.github/workflows/login.yml
+++ b/.github/workflows/login.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt install zsh
 
       # Runs a single command using the runners shell
       - name: Check shell scripts

--- a/slurm/etc/slurm/randomize-gpu
+++ b/slurm/etc/slurm/randomize-gpu
@@ -1,0 +1,12 @@
+#! /usr/bin/zsh -e
+
+setopt extended_glob
+# --force bypasses the error
+# "rm: missing operand", when there are no files to delete.
+rm --force /dev/rNvidia[0-9]#(N)
+nvidias=( $(printf '%s\n' /dev/nvidia[0-9]# | shuf) )
+
+for ((i = 1; i <= $#nvidias; i++)) do
+	echo "Link "${nvidias[$i]}" to rNvidia$((i-1))"
+	ln -s ${nvidias[$i]} /dev/rNvidia$((i-1))
+done

--- a/slurm/etc/systemd/system/multi-user.target.wants/slurmd.service
+++ b/slurm/etc/systemd/system/multi-user.target.wants/slurmd.service
@@ -7,6 +7,8 @@ Documentation=man:slurmd(8)
 [Service]
 Type=forking
 EnvironmentFile=-/etc/default/slurmd
+ExecStartPre=/usr/bin/nvidia-smi
+ExecStartPre=/etc/slurm-llnl/randomize-gpu
 ExecStart=/usr/sbin/slurmd $SLURMD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/slurmd.pid


### PR DESCRIPTION
This requires gres.conf refers to rNvidia files.

Also run nvidia-smi before slurmd to initialize GPU.