### PR TITLE
Fix error that slurm output log doesn't update

### DIFF
--- a/slurm-examples/pytorch.slurm
+++ b/slurm-examples/pytorch.slurm
@@ -24,4 +24,5 @@
 
 source /opt/anaconda3/bin/activate
 conda activate torch
-./pytorch.py
+# -u: disable buffer, let print flush to the output file.
+python -u pytorch.py

--- a/slurm-examples/tf.slurm
+++ b/slurm-examples/tf.slurm
@@ -25,4 +25,5 @@
 source /opt/anaconda3/bin/activate
 conda activate tf
 TF_CPP_MIN_LOG_LEVEL=2
-./tf.py
+# -u: disable buffer, let print flush to the output file.
+python -u tf.py


### PR DESCRIPTION
When we commit jobs, slurm does not write the program output to the `#SBATCH --output=%j.out`  file frequently. 

Quite often, we use sbatch to submit a job, and see the job is running, but the log file is empty. We have no idea if the program is actually doing its job or there is something wrong.

This PR revises the slurm script and shows that for python programs, we need to add [the `-u`  flag](https://docs.python.org/3/using/cmdline.html#cmdoption-u) so that Python stdout and stderr are unbuffered. 

In my experiments with the -u flag, my `%j.out` file gets updated every tens of seconds.

This approach requires little modification while another way is to add `flush=True` to every print statement.