### PR TITLE
Add the sit alias

### DIFF
--- a/login/etc/skel/.bash_aliases
+++ b/login/etc/skel/.bash_aliases
@@ -9,6 +9,8 @@ alias squeueF='squeue --Format "JobID:8,Partition:11,Name:10,UserName:10,StateCo
 function sit
 {
 	if [[ "$ZSH_NAME" ]]; then 
+		# If zsh runs with emulate -L, option changes are local.
+		# But I still set local_options for safety.
 		setopt local_options SH_WORD_SPLIT
 	fi
 
@@ -25,4 +27,13 @@ function sit
 	command srun --pty $option $SHELL -i
 }
 
-complete -W "--internet -g" sit
+if [[ "$ZSH_NAME" ]]; then 
+	function _sit() {
+		_arguments '-g[Use 1 GPU]' \
+				'--internet[Choose a node with high speed Internet connection]'
+	}
+
+	compdef _sit sit
+else
+	complete -W "--internet -g" sit
+fi

--- a/login/etc/skel/.bash_aliases
+++ b/login/etc/skel/.bash_aliases
@@ -8,6 +8,10 @@ alias squeueF='squeue --Format "JobID:8,Partition:11,Name:10,UserName:10,StateCo
 
 function sit
 {
+	if [[ "$ZSH_NAME" ]]; then 
+		setopt local_options SH_WORD_SPLIT
+	fi
+
 	option=
 	while [[ "$#" -gt 0 ]]; do
 		case $1 in

--- a/login/etc/skel/.bash_aliases
+++ b/login/etc/skel/.bash_aliases
@@ -6,9 +6,19 @@
 
 alias squeueF='squeue --Format "JobID:8,Partition:11,Name:10,UserName:10,StateCompact:4,TimeUsed:11,NumCPUs:5,tres-per-node:15,ReasonList"'
 
-function sinteractive
+function sit
 {
-	command srun --pty "$@" bash -i
+	option=
+	while [[ "$#" -gt 0 ]]; do
+		case $1 in
+			--internet) option="$option --x11 -w tatooine" ;;
+			-g) option="$option --gres=gpu:1 --nice" ;;
+			*) option="$option $1";;
+		esac
+		shift
+	done
+	
+	command srun --pty $option $SHELL -i
 }
 
-alias sinteractive-g='sinteractive --gres=gpu --nice'
+complete -W "--internet -g" sit


### PR DESCRIPTION
This PR formalizes the `sit` command we have been using for a long time.

`sit` is a shell alias instead of an executable on the disk because sit is a simple wrapper of `srun`. If people don't like sit or want to revise sit, in this way they can just edit their .bash_alias. If I made sit an executable, people couldn't exclude sit from their shell prompt. Say, people type `s` and press tab, shell will prompt `sit`, and people couldn't make sit not appear. 