### PR TITLE
Add GitHub Actions for testing btrfs commands

### DIFF
--- a/.github/workflows/btrfs-entrypoint.sh
+++ b/.github/workflows/btrfs-entrypoint.sh
@@ -21,5 +21,5 @@ cd login
 
 cd tests/login
 
-wget https://raw.githubusercontent.com/kward/shunit2/v2.1.8/shunit2
+wget https://raw.githubusercontent.com/kward/shunit2/d0a57ff2e6c5d8fbd27f9bebd1896037ce628f9d/shunit2
 ./btrfs_test.sh

--- a/.github/workflows/btrfs-entrypoint.sh
+++ b/.github/workflows/btrfs-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Requires a rootfull and privileged contrainer.
+
+apt update
+sed 's/#.*//' login/requirements.txt | xargs apt install -y
+apt install -y wget
+
+#git clone --depth 10 --branch v2.1.8 https://github.com/kward/shunit2.git /var/opt/shunit2
+#export PATH="$PATH:/var/opt/shunit2/"
+
+
+
+# Install mpi-servers
+# Parenthesis runs in subshell so we don't have to `cd` back.
+(
+cd login
+./install.sh
+)
+
+
+cd tests/login
+
+wget https://raw.githubusercontent.com/kward/shunit2/v2.1.8/shunit2
+./btrfs_test.sh

--- a/.github/workflows/btrfs.yml
+++ b/.github/workflows/btrfs.yml
@@ -1,0 +1,26 @@
+# This is a basic workflow to help you get started with Actions
+
+name: btrfs
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Run docker
+        run: |
+          sudo docker run -v `pwd`:/mpi-servers -w /mpi-servers --privileged ubuntu:20.04 .github/workflows/btrfs-entrypoint.sh

--- a/login/etc/update-motd.d/76-disk-quota
+++ b/login/etc/update-motd.d/76-disk-quota
@@ -8,10 +8,9 @@ if [[ -e /etc/diskquota/enable ]]; then
 else
 	percent=$(df --output=pcent /home | grep -o -P '\d+')
 	if (( percent >= 45 )); then
-		echo -n "目前/home目录已经${percent}%满。如果达到50%，将会启动磁盘配额。"
-	else
-		exit
+		echo "目前/home目录已经${percent}%满。如果达到50%，将会启动磁盘配额。"
 	fi
+	exit 0
 fi
 
 limit=$(diskquota limit)

--- a/login/install.sh
+++ b/login/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/zsh
+
+
+
+
+function needCopy()
+{
+	foldersToCopy=()
+	file=$1
+	for folder in $foldersToCopy
+	do
+		#echo "file=$file, folder=$folder"
+		if [[ $file = ${folder}* ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+untrackedFiles=$(git status -uall --short --porcelain | awk '$1==''"??"'' {print $2}')
+
+
+for file in **/*(.)
+do
+	if [[ $0 = *$file ]]; then
+		echo "skip install file"
+		continue
+	fi
+
+	if (( ${untrackedFiles[(Ie)$file]} )); then
+		echo "skip untracked file: $file"
+		continue
+	fi
+
+	if needCopy $file ; then
+		# echo "copy $file"
+		cp $PWD/$file /$file
+	else
+		# echo "link $file"
+		ln -s $PWD/$file /$file
+	fi
+done

--- a/login/requirements.txt
+++ b/login/requirements.txt
@@ -1,0 +1,4 @@
+# The packages listed below will be installed by apt.
+btrfs-progs
+git
+zsh

--- a/tests/login/btrfs_test.sh
+++ b/tests/login/btrfs_test.sh
@@ -24,9 +24,8 @@ testWhenDiskMoreThan45 () {
 	percent=$(df --output=pcent --sync /home | grep -o -P '\d+')
 	msg=$(/etc/update-motd.d/76-disk-quota 2>&1)
 
-	if [[ "$msg" == *"ERROR"* ]]; then
-		fail $"MOTD shouldn't throw error when /home is ${percent}% full but diskquota is not enabled.\n$msg"
-	fi
+	assertNotContains $"MOTD shouldn't throw error when /home is ${percent}% full but diskquota is not enabled.\n$msg\n" \
+					"$msg" "ERROR"
 }
 
 source shunit2

--- a/tests/login/btrfs_test.sh
+++ b/tests/login/btrfs_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+setUp() {
+	mkdir /ramdisks
+	mount -t tmpfs tmpfs /ramdisks
+	mkdir /ramdisks/raw /ramdisks/mnt
+	dd if=/dev/zero of=/ramdisks/raw/disk0 bs=1M count=256
+
+
+	# jb=$(jobs -p)
+	# if [[ -n "$jb" ]]; then
+	#   wait "$jb"
+	# fi
+
+	mkfs.btrfs /ramdisks/raw/disk0
+	mount -o loop /ramdisks/raw/disk0 /home
+
+}
+
+
+
+testWhenDiskMoreThan45 () {
+	dd if=/dev/urandom of=/home/filler.bin bs=1M count=80 >/dev/null
+	percent=$(df --output=pcent --sync /home | grep -o -P '\d+')
+	msg=$(/etc/update-motd.d/76-disk-quota 2>&1)
+
+	if [[ "$msg" == *"ERROR"* ]]; then
+		fail $"MOTD shouldn't throw error when /home is ${percent}% full but diskquota is not enabled.\n$msg"
+	fi
+}
+
+source shunit2


### PR DESCRIPTION
closes #62 

![mmexport1635077454484](https://user-images.githubusercontent.com/614159/138593540-cfef8f50-473a-4188-8cf7-c8e2ec0e2fe8.jpg)

As people have noticed, when disk quota is not enabled, MOTD still outputs the limit, which is incorrect.

The real reason for this bug is that we don't have automated tests for our diskquota programs.

This PR not only adds automated tests for diskquota programs but also fixes the aforementioned bug.