### PR TITLE
Trim real memory

### DIFF
--- a/slurm/etc/slurm/slurm.conf
+++ b/slurm/etc/slurm/slurm.conf
@@ -39,5 +39,5 @@ PropagateResourceLimitsExcept=MEMLOCK
 GresTypes=gpu
 PartitionName=speedy	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=2	Default=YES	MaxTime=6:00:00	State=UP
 PartitionName=normal	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=1	MaxTime=5-00:00:00	State=UP
-NodeName=eureka	NodeAddr=eureka	Gres=gpu:10	CPUs=48	Boards=1	SocketsPerBoard=2	CoresPerSocket=12	ThreadsPerCore=2	RealMemory=128573
-NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2	RealMemory=128516
+NodeName=eureka	NodeAddr=eureka	Gres=gpu:10	CPUs=48	Boards=1	SocketsPerBoard=2	CoresPerSocket=12	ThreadsPerCore=2	RealMemory=128000
+NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2	RealMemory=128000

--- a/slurm/etc/slurm/slurm.conf
+++ b/slurm/etc/slurm/slurm.conf
@@ -39,6 +39,5 @@ PropagateResourceLimitsExcept=MEMLOCK
 GresTypes=gpu
 PartitionName=speedy	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=2	Default=YES	MaxTime=6:00:00	State=UP
 PartitionName=normal	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=1	MaxTime=5-00:00:00	State=UP
-NodeName=eureka	NodeAddr=eureka	Gres=gpu:10	CPUs=48	Boards=1	SocketsPerBoard=2	CoresPerSocket=12	ThreadsPerCore=2	RealMemory=128000
-NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2	
-# RealMemory=128000
+NodeName=eureka	NodeAddr=eureka	Gres=gpu:10	CPUs=48	Boards=1	SocketsPerBoard=2	CoresPerSocket=12	ThreadsPerCore=2
+NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2

--- a/slurm/etc/slurm/slurm.conf
+++ b/slurm/etc/slurm/slurm.conf
@@ -40,4 +40,5 @@ GresTypes=gpu
 PartitionName=speedy	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=2	Default=YES	MaxTime=6:00:00	State=UP
 PartitionName=normal	Nodes=eureka,tatooine	DefCpuPerGPU=2	PriorityTier=1	MaxTime=5-00:00:00	State=UP
 NodeName=eureka	NodeAddr=eureka	Gres=gpu:10	CPUs=48	Boards=1	SocketsPerBoard=2	CoresPerSocket=12	ThreadsPerCore=2	RealMemory=128000
-NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2	RealMemory=128000
+NodeName=tatooine	NodeAddr=tatooine	Gres=gpu:4	CPUs=20	Boards=1	SocketsPerBoard=1	CoresPerSocket=10	ThreadsPerCore=2	
+# RealMemory=128000


### PR DESCRIPTION
The total memory of Tatooine was 128517. 

Then I rebooted Tatooine many times, and updated BIOS. 

Then the total memory became 128516.

I'm not sure if the BIOS update or something else would change total memory.

To avoid memory size change, trim memory size to 000.