### PR TITLE
Installing GUI applications may activate the graphical target

### DIFF
--- a/setup-gui.sh
+++ b/setup-gui.sh
@@ -7,3 +7,7 @@ ttf-wqy-zenhei
 )
 sudo apt install -y "${arr[@]}"
 sudo touch /root/.Xauthority
+
+# Installing GUI applications may activate the graphical target.
+sudo systemctl isolate multi-user.target
+sudo systemctl set-default multi-user.target


### PR DESCRIPTION
"Rumor" has it that installing GUI applications may activate the graphical target.

A script should be self-contained. Although setup.sh has the two lines, setup-gui.sh is better to include the two lines if setup-gui.sh is able to change a command line server to a GUI server.